### PR TITLE
Move database secrets to .env file where they belong

### DIFF
--- a/server/controllers/projectController.js
+++ b/server/controllers/projectController.js
@@ -142,10 +142,8 @@ projectController.getProjects = (req, res, next) => {
           for (let i = 0; i < allProjectData.rows.length; i++) {
             for (const item of res.locals.projects) {
               if (item.projectid == allProjectData.rows[i]._id) {
-
                 item.projectName = allProjectData.rows[i].projectname;
                 item.projectDescription =
-
                   allProjectData.rows[i].projectdescription;
               }
             }

--- a/server/models/projectModels.js
+++ b/server/models/projectModels.js
@@ -1,12 +1,10 @@
 const { Pool } = require('pg');
-//const key = process.env.SECRET_KEY;
-//require('dotenv').config();
+require('dotenv').config();
 
-const PG_URI =
-  'postgres://fkmtqvcp:CFXNXOGrEfb6wqPJWyTjWwc5xJh8hB0F@trumpet.db.elephantsql.com/fkmtqvcp';
-// 'postgres://uiziiixt:6qoAfgoyFy6N4K8Y_yXBFZEM2KuN-m0z@hansken.db.elephantsql.com/uiziiixt';
+// const PG_URI = process.env.PG_URI;
+const PG_URI = process.env.PG_URI;
 
-// postgres://fkmtqvcp:CFXNXOGrEfb6wqPJWyTjWwc5xJh8hB0F@trumpet.db.elephantsql.com/fkmtqvcp
+console.log(PG_URI);
 
 const pool = new Pool({
   connectionString: PG_URI,

--- a/server/server.js
+++ b/server/server.js
@@ -7,12 +7,9 @@ const bodyParser = require('body-parser');
 const accountRouter = require('./routes/accountRouter');
 const projectRouter = require('./routes/projectRouter');
 const subtaskRouter = require('./routes/subtaskRouter');
-//require('dotenv').config();
-//once we have a secret key available contingent on db
-const key =
-  'mongodb+srv://danger-snake:C2b4le0QvZavcgP3@danger-snake.cazraa2.mongodb.net/?retryWrites=true&w=majority';
-// old key from the original team
-// 'mongodb+srv://mzkrasner:element@cluster0.gxacbcq.mongodb.net/?retryWrites=true&w=majority';
+require('dotenv').config();
+// note this is a URL, not a key, but that's what they named it and I don't want to change it
+const key = process.env.MONGO_URL;
 mongoose.connect(key);
 
 const PORT = 3000;


### PR DESCRIPTION
A GitHub bot emailed me warning that we uploaded the secrets for our databases into our repository. I moved them to a .env file where they belong. I'll share it with the team in a secure channel.